### PR TITLE
FIX: Show the BCC option when messaging a single group

### DIFF
--- a/assets/javascripts/discourse/components/bcc-checkbox.js.es6
+++ b/assets/javascripts/discourse/components/bcc-checkbox.js.es6
@@ -7,11 +7,13 @@ export default Component.extend({
   bccAvailable: computed(
     "creatingPrivateMessage",
     "targetRecipients",
+    "targetGroups",
     function() {
       return (
         this.currentUser.staff &&
         this.creatingPrivateMessage &&
-        (this.targetRecipients || "").split(",").length > 1
+        ((this.targetRecipients || "").split(",").length > 1 ||
+          this.targetGroups)
       );
     }
   )

--- a/assets/javascripts/discourse/templates/connectors/composer-fields/bcc-checkbox.hbs
+++ b/assets/javascripts/discourse/templates/connectors/composer-fields/bcc-checkbox.hbs
@@ -1,4 +1,5 @@
 {{bcc-checkbox
   creatingPrivateMessage=model.creatingPrivateMessage
   targetRecipients=model.targetRecipients
-  checked=model.use_bcc}}
+  checked=model.use_bcc
+  targetGroups=model.hasTargetGroups}}


### PR DESCRIPTION
[Context](https://meta.discourse.org/t/discourse-bcc-send-individual-pms-to-users/134721/22?u=roman_rizzi)