### PR TITLE
Personalize Message with Recipient's Name

### DIFF
--- a/app/jobs/bcc_post.rb
+++ b/app/jobs/bcc_post.rb
@@ -21,6 +21,8 @@ class ::Jobs::BccPost < ::Jobs::Base
 
   def send_to(targets, targets_key, params, sender)
     targets.each do |target|
+      params["raw"] = params["raw"].gsub(/{username}/i, target)
+      params["raw"] = params["raw"].gsub(/{@username}/i, "@" + target)
       creator = PostCreator.new(sender, params.merge(Hash[targets_key, target]))
       creator.create
     end

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -55,15 +55,12 @@ describe ::Jobs::BccPost do
       expect(Topic.count).to eq(topic_count + 2)
     end
     
-    it 'works with personalization' do
-      edited_params = create_params
-      edited[:raw] += " to {username}"
-      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: edited)
+    it 'works with username and email personalization' do
+      topic_count = Topic.count
+      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to {username}", target_emails: 'test@test.com'))
       
-      expect(Post.find_by({topic_id: Topic.count-1}).raw[
-        -user1.username.length, user1.username.length
-        ]).to eq(user1.username)
-    end  
+      expect(Topic.count).to eq(topic_count + 3)
+    end 
       
   end
 end

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -58,12 +58,13 @@ describe ::Jobs::BccPost do
     end
     
     it 'works with username and email personalization' do
-      topic_count = Topic.count
 
       ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to {username}", target_emails: 'test@test.com'))
-      
-      expect(Topic.count).to eq(topic_count + 3)
-    end 
+
+      raw = Topic.last.excerpt
+
+      expect(raw).to include(user0.username).or include(user1.username).or include("test@test.com")
+    end
       
   end
 end

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -54,5 +54,16 @@ describe ::Jobs::BccPost do
 
       expect(Topic.count).to eq(topic_count + 2)
     end
+    
+    it 'works with personalization' do
+      edited_params = create_params
+      edited[:raw] += " to {username}"
+      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: edited)
+      
+      expect(Post.find_by({topic_id: Topic.count-1}).raw[
+        -user1.username.length, user1.username.length
+        ]).to eq(user1.username)
+    end  
+      
   end
 end

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 describe ::Jobs::BccPost do
   fab!(:sender) { Fabricate(:moderator) }
   fab!(:user0) { Fabricate(:user) }
@@ -57,6 +59,7 @@ describe ::Jobs::BccPost do
     
     it 'works with username and email personalization' do
       topic_count = Topic.count
+
       ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to {username}", target_emails: 'test@test.com'))
       
       expect(Topic.count).to eq(topic_count + 3)

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -57,14 +57,23 @@ describe ::Jobs::BccPost do
       expect(Topic.count).to eq(topic_count + 2)
     end
     
-    it 'works with username and email personalization' do
+    it 'works with standard personalization' do
 
       ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to {username}", target_emails: 'test@test.com'))
 
-      raw = Topic.last.excerpt
+      post = Post.find_by(raw: "this is the content I want to send to #{user0.username}")
 
-      expect(raw).to include(user0.username).or include(user1.username).or include("test@test.com")
-    end
+      expect(post).to_not be_nil
+    end 
+
+    it 'works with mention personalization' do
+
+      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to {@username}", target_emails: 'test@test.com'))
+
+      post = Post.find_by(raw: "this is the content I want to send to @#{user0.username}")
+
+      expect(post).to_not be_nil
+    end 
       
   end
 end


### PR DESCRIPTION
RE: https://meta.discourse.org/t/bcc-add-username-placeholder/177343

Added the ability to use `{username}` and `{@username}` in the overall message which customizes to include each recipients name.