### PR TITLE
Change Syntax & Add Name Personalization

### DIFF
--- a/app/jobs/bcc_post.rb
+++ b/app/jobs/bcc_post.rb
@@ -19,10 +19,15 @@ class ::Jobs::BccPost < ::Jobs::Base
 
   private
 
-  def send_to(targets, targets_key, params, sender, isUsername)
+  def send_to(targets, targets_key, params, sender)
     targets.each do |target|
+      temp_params = params
       temp_params["raw"] = temp_params["raw"].gsub(/%{username}/i, target)
       temp_params["raw"] = temp_params["raw"].gsub(/%{@username}/i, "@" + target)
+      user = User.find_by_username_or_email(target)
+      if !user.nil? then
+        temp_params["raw"] = temp_params["raw"].gsub(/%{name}/i, user.name)
+      end
       creator = PostCreator.new(sender, temp_params.merge(Hash[targets_key, target]))
       creator.create
     end

--- a/app/jobs/bcc_post.rb
+++ b/app/jobs/bcc_post.rb
@@ -19,11 +19,10 @@ class ::Jobs::BccPost < ::Jobs::Base
 
   private
 
-  def send_to(targets, targets_key, params, sender)
+  def send_to(targets, targets_key, params, sender, isUsername)
     targets.each do |target|
-      temp_params = params
-      temp_params["raw"] = temp_params["raw"].gsub(/{username}/i, target)
-      temp_params["raw"] = temp_params["raw"].gsub(/{@username}/i, "@" + target)
+      temp_params["raw"] = temp_params["raw"].gsub(/%{username}/i, target)
+      temp_params["raw"] = temp_params["raw"].gsub(/%{@username}/i, "@" + target)
       creator = PostCreator.new(sender, temp_params.merge(Hash[targets_key, target]))
       creator.create
     end

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -77,10 +77,9 @@ describe ::Jobs::BccPost do
       
 
     it 'works with name personalization' do
-      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to %{@name}", target_emails: 'test@test.com'))
-      puts "TESTHEREABC"
-      puts user0.name
-      post = Post.find_by(raw: "this is the content I want to send to @#{user0.name}")
+      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to %{name}", target_emails: 'test@test.com'))
+     
+      post = Post.find_by(raw: "this is the content I want to send to #{user0.name}")
 
       expect(post).to_not be_nil
     end

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -59,7 +59,7 @@ describe ::Jobs::BccPost do
     
     it 'works with standard personalization' do
 
-      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to {username}", target_emails: 'test@test.com'))
+      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to %{username}", target_emails: 'test@test.com'))
 
       post = Post.find_by(raw: "this is the content I want to send to #{user0.username}")
 
@@ -68,7 +68,7 @@ describe ::Jobs::BccPost do
 
     it 'works with mention personalization' do
 
-      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to {@username}", target_emails: 'test@test.com'))
+      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to %{@username}", target_emails: 'test@test.com'))
 
       post = Post.find_by(raw: "this is the content I want to send to @#{user0.username}")
 

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -75,5 +75,14 @@ describe ::Jobs::BccPost do
       expect(post).to_not be_nil
     end 
       
+
+    it 'works with name personalization' do
+      ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params.merge("raw": "this is the content I want to send to %{@name}", target_emails: 'test@test.com'))
+      puts "TESTHEREABC"
+      puts user0.name
+      post = Post.find_by(raw: "this is the content I want to send to @#{user0.name}")
+
+      expect(post).to_not be_nil
+    end
   end
 end


### PR DESCRIPTION
RE: [Request](https://meta.discourse.org/t/improving-the-placeholders-for-the-bcc-plugin/186861)

This changes the syntax of personalization to be `%{variable}` instead of `{variable}`, as well creates a new variable, `name`.