### PR TITLE
FIX: do not crash when user.name is nil

### DIFF
--- a/app/jobs/bcc_post.rb
+++ b/app/jobs/bcc_post.rb
@@ -26,7 +26,7 @@ class ::Jobs::BccPost < ::Jobs::Base
 
       user = User.find_by_username_or_email(target)
 
-      if user && user.name
+      if user&.name
         raw.gsub!(/%{name}/i, user.name)
       end
 

--- a/app/jobs/bcc_post.rb
+++ b/app/jobs/bcc_post.rb
@@ -25,7 +25,8 @@ class ::Jobs::BccPost < ::Jobs::Base
       raw.gsub!(/%{@username}/i, "@" + target)
 
       user = User.find_by_username_or_email(target)
-      if !user.nil? then
+
+      if user && user.name
         raw.gsub!(/%{name}/i, user.name)
       end
 

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -34,7 +34,7 @@ describe ::Jobs::BccPost do
     end
 
     it "does not crash when user's name is empty" do
-      user0.update_columns(name: nil)
+      user0.update!(name: nil)
       expect { ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params) }.not_to raise_error
     end
 

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -33,6 +33,11 @@ describe ::Jobs::BccPost do
       expect(Topic.count).to eq(topic_count + 2)
     end
 
+    it "is not crashing when user.name is nil" do
+      user0.update_columns(name: nil)
+      expect { ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params) }.not_to raise_error
+    end
+
     it 'works when mixing emails and usernames' do
       SiteSetting.enable_staged_users = true
       topic_count = Topic.count

--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -33,7 +33,7 @@ describe ::Jobs::BccPost do
       expect(Topic.count).to eq(topic_count + 2)
     end
 
-    it "is not crashing when user.name is nil" do
+    it "does not crash when user's name is empty" do
       user0.update_columns(name: nil)
       expect { ::Jobs::BccPost.new.execute(user_id: sender.id, create_params: create_params) }.not_to raise_error
     end


### PR DESCRIPTION
The job should not explode when `user.name` is nil