### PR TITLE
FIX: Use modifyClass API instead of calling reopen

### DIFF
--- a/assets/javascripts/discourse/initializers/setup-bcc.js.es6
+++ b/assets/javascripts/discourse/initializers/setup-bcc.js.es6
@@ -1,5 +1,6 @@
 import { ajax } from "discourse/lib/ajax";
 import { Result } from "discourse/adapters/rest";
+import { withPluginApi } from "discourse/lib/plugin-api";
 
 export default {
   name: "setup-bcc",
@@ -12,21 +13,24 @@ export default {
       composer.class.serializeToDraft("use_bcc");
     }
 
-    let adapter = container.lookup("adapter:post");
-    adapter.reopen({
-      createRecord(store, type, args) {
-        if (type === "post" && args.use_bcc) {
-          return ajax("/posts/bcc", {
-            method: "POST",
-            data: args
-          }).then(json => {
-            return new Result(json.post, json);
-          });
-        } else {
-          delete args.use_bcc;
-          return this._super(store, type, args);
-        }
-      }
+    withPluginApi("0.8.10", (api) => {
+      api.modifyClass("adapter:post", {
+        pluginId: "discourse-bcc",
+
+        createRecord(store, type, args) {
+          if (type === "post" && args.use_bcc) {
+            return ajax("/posts/bcc", {
+              method: "POST",
+              data: args,
+            }).then((json) => {
+              return new Result(json.post, json);
+            });
+          } else {
+            delete args.use_bcc;
+            return this._super(store, type, args);
+          }
+        },
+      });
     });
-  }
+  },
 };


### PR DESCRIPTION
This is the recommended way of modifying classes and can help plugins
interact with each other in a more predictable way.