### PR TITLE
FIX: BCC Sending to email addresses

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -48,7 +48,9 @@ after_initialize do
       end
     end
 
-    if usernames.size < 2
+    emails = Set.new((@manager_params[:target_emails] || '').split(','))
+
+    if (usernames.size + emails.size) < 2
       return render_bcc(status: false) { |result| result.add_error(I18n.t("bcc.too_few_users")) }
     end
 

--- a/spec/requests/post_controller_spec.rb
+++ b/spec/requests/post_controller_spec.rb
@@ -67,6 +67,15 @@ describe PostsController do
       expect(json['message']).to be_present
     end
 
+    it "succeeds with email addresses" do
+      post '/posts/bcc.json', params: create_params.merge(target_recipients: 'evil@example.com,trout@example.com')
+      expect(Jobs::BccPost.jobs.length).to eq(1)
+      expect(response.code).to eq('200')
+      json = JSON.parse(response.body)
+      expect(json['route_to']).to be_present
+      expect(json['message']).to be_present
+    end
+
     describe 'xxxxx' do
       before do
         @group = Fabricate(:group, messageable_level: Group::ALIAS_LEVELS[:everyone])


### PR DESCRIPTION
This fixes sending to email addresses as recipients. Without this change
you will get this error when trying to send to multiple email addresses:

> You must send the personal message to at least two participants