### PR TITLE
DEV: Reduce Server Load

### DIFF
--- a/app/jobs/bcc_post.rb
+++ b/app/jobs/bcc_post.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
 class ::Jobs::BccPost < ::Jobs::Base
+
+  sidekiq_options queue: 'low'
+
   def execute(args)
     return unless SiteSetting.bcc_enabled?
 
     sender = User.find_by(id: args[:user_id])
     return unless sender.present?
 
+    targets = args[:targets]
+    targets_key = args[:targets_key]
     create_params = args[:create_params]
     create_params[:skip_validations] = true
 
-    split_usernames = (create_params.delete(:target_usernames) || '').split(',')
-    split_emails = (create_params.delete(:target_emails) || '').split(',')
-
-    send_to(split_usernames, :target_usernames, create_params, sender)
-    send_to(split_emails, :target_emails, create_params, sender)
+    send_to(targets, targets_key, create_params, sender)
   end
 
   private

--- a/plugin.rb
+++ b/plugin.rb
@@ -33,20 +33,15 @@ after_initialize do
       end
 
       def batch_targets(targets, targets_key)
-        targets = targets.to_a
-        batch_start = 0
-        batch_end = DiscourseBCC::BATCH_SIZE - 1
-        while batch_start <= targets.size && targets.size > 0
-          Jobs.enqueue(
-            :bcc_post,
-            user_id: current_user.id,
-            create_params: @manager_params,
-            targets_key: targets_key,
-            targets: targets[batch_start..batch_end]
-          )
-          batch_start += DiscourseBCC::BATCH_SIZE
-          batch_end += DiscourseBCC::BATCH_SIZE
-        end
+        targets.each_slice(DiscourseBBC::BATCH_SIZE) { |t|
+            Jobs.enqueue(
+              :bcc_post,
+              user_id: current_user.id,
+              create_params: @manager_params,
+              targets_key: targets_key,
+              targets: t
+            )
+          }
       end
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -33,15 +33,15 @@ after_initialize do
       end
 
       def batch_targets(targets, targets_key)
-        targets.each_slice(DiscourseBBC::BATCH_SIZE) { |t|
-            Jobs.enqueue(
-              :bcc_post,
-              user_id: current_user.id,
-              create_params: @manager_params,
-              targets_key: targets_key,
-              targets: t
-            )
-          }
+        targets.each_slice(DiscourseBCC::BATCH_SIZE) do |t|
+          Jobs.enqueue(
+            :bcc_post,
+            user_id: current_user.id,
+            create_params: @manager_params,
+            targets_key: targets_key,
+            targets: t
+          )
+        end
       end
     end
   end

--- a/spec/requests/post_controller_spec.rb
+++ b/spec/requests/post_controller_spec.rb
@@ -96,7 +96,7 @@ describe PostsController do
         expect(response.code).to eq('200')
         job = Jobs::BccPost.jobs[0]
         expect(job).to be_present
-        usernames = job['args'].first['create_params']['target_usernames'].split(',')
+        usernames = job['args'].first['targets']
         expect(usernames).to match_array([@user0.username, @user1.username, @user2.username])
       end
 
@@ -108,7 +108,7 @@ describe PostsController do
         expect(response.code).to eq('200')
         job = Jobs::BccPost.jobs[0]
         expect(job).to be_present
-        usernames = job['args'].first['create_params']['target_usernames'].split(',')
+        usernames = job['args'].first['targets']
         expect(usernames).to match_array([@user0.username, @user1.username])
       end
     end


### PR DESCRIPTION
This commit attempts to smooth out server load when sending PMs/emails
to hundreds or even thousands of users by batching the creation of
sidekiq jobs into groups of 20 instead of using a single sidekiq job to
do all of the sending.

Before when a single sidekiq job was doing all the work this would
hammer a single CPU/worker. Now that multiple sidekiq jobs are created
for sending out messages we can take advantage of using multiple workers
to share the load.

- Switched to using a lower priority queue
- Removed splitting up the usernames and emails from the sidekiq job
- Changed the sidekiq job args so that it now accepts a `targets` and a
`targets_key` param
- The bcc controller endpoint now handles splitting up the users in
batches and creating single sidekiq job per patch
- Cleaned up all the tests to match the new format