### PR TITLE
FIX: Groups being mentioned in each message

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -78,7 +78,7 @@ after_initialize do
       return render_bcc(status: false) { |result| result.add_error(post.errors[:raw]) }
     end
 
-    @manager_params.except(:target_users, :target_group_names, :target_emails)
+    @manager_params.except!(:target_users, :target_group_names, :target_emails)
 
     # Queue up jobs in batches so that when sending hundreds or thousands of emails we
     # can take advantage of multiple workers

--- a/spec/requests/post_controller_spec.rb
+++ b/spec/requests/post_controller_spec.rb
@@ -136,6 +136,10 @@ describe PostsController do
         expect(job_batch_2).to be_present
         usernames_batch_1 = job_batch_1['args'].first['targets']
         usernames_batch_2 = job_batch_2['args'].first['targets']
+        create_params = job_batch_2['args'].first['create_params']
+        expect(create_params.key?('target_group_names')).to eq(false)
+        expect(create_params.key?('target_users')).to eq(false)
+        expect(create_params.key?('target_emails')).to eq(false)
         expect(usernames_batch_1.size).to eq(DiscourseBCC::BATCH_SIZE)
         expect(usernames_batch_2.size).to eq(5)
       end


### PR DESCRIPTION
Strip out `target_groups_names` when sending a BCC PM.

Because we are sending a single message per user we need to clean up the
create_params we are sending to the PostCreator. This is a regression
introduced in my previous commit: 668bd99be87ee9cb4d7413c101eae9538e87262a

If we leave in the `target_groups_names` param, each PM will say its
between the group and the sender instead of between the individual and
the sender.