### PR TITLE
DEV: Fix specs for personal_message_enabled_groups setting

### DIFF
--- a/spec/jobs/bcc_post_spec.rb
+++ b/spec/jobs/bcc_post_spec.rb
@@ -25,6 +25,7 @@ describe ::Jobs::BccPost do
   context "when enabled" do
     before do
       SiteSetting.bcc_enabled = true
+      Group.refresh_automatic_groups!
     end
 
     it "will send messages to each user" do


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/18437, we are removing any references to enable_personal_messages in core and using only personal_message_enabled_groups, which requires auto groups to be assigned in certain specs for them to keep working.